### PR TITLE
tower can be moved

### DIFF
--- a/src/maps/level1.json
+++ b/src/maps/level1.json
@@ -7,6 +7,14 @@
          "height":14,
          "name":"towerPlace",
          "opacity":1,
+         "properties":
+            {
+             "canPlace":true
+            },
+         "propertytypes":
+            {
+             "canPlace":"bool"
+            },
          "type":"tilelayer",
          "visible":true,
          "width":21,

--- a/src/spriteAtlas.json
+++ b/src/spriteAtlas.json
@@ -1,0 +1,3 @@
+{
+	"basicTower": 24
+}


### PR DESCRIPTION
A single tower (sprite selection to be made) can be taken and placed from the bottom left corner of the screen. If an attempt is made to place on the path, the sprite will return to starting position, otherwise, the sprite will lock into place on a tile. No logic to subtract gold/generate new towers that may be purchased has been added